### PR TITLE
Removed min-height on paragraphs, because in IE9 it overrode the IE7 UA-C

### DIFF
--- a/src/wymeditor/iframe/default/wymiframe.css
+++ b/src/wymeditor/iframe/default/wymiframe.css
@@ -48,8 +48,6 @@
   pre           { background-color:transparent; border: 1px solid white; }
 
 /* Gecko min height fix */
-  p             { min-height: 1em; } /*min-height is needed under Firefox, because empty parargraphs */
-  *+html p      { min-height: auto; } /* but we have to remove it under IE7 because it triggers the 'haslayout' mode */
   td            { height: 1.6em; }
  
 /* labels */


### PR DESCRIPTION
Removed min-height on paragraphs, because in IE9 it overrode the IE7 UA-Compatibility header.

fixes #245
