### PR TITLE
Issue 266: broken makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ archive: pack min
 	@@cp -pR ${SRC_DIR}/wymeditor ${BUILD_DIR}/build/wymeditor/
 	@@rm ${BUILD_DIR}/build/wymeditor/wymeditor/*.js
 	@@cp ${WE} ${WE_PACK} ${WE_MIN} ${BUILD_DIR}/build/wymeditor/wymeditor/
-	@@cp -pR ${SRC_DIR}/README ${BUILD_DIR}/build/wymeditor/
+	@@cp -pR ./README.md ${BUILD_DIR}/build/wymeditor/
+	@@cp -pR ./CHANGELOG.rst ${BUILD_DIR}/build/wymeditor/
 	@@cp -pR ${SRC_DIR}/examples ${BUILD_DIR}/build/wymeditor/
 	@@cp -pR ${SRC_DIR}/jquery ${BUILD_DIR}/build/wymeditor/
 	@@tar -C ${BUILD_DIR}/build -czf ${WE_ARCH} --exclude '.svn' wymeditor


### PR DESCRIPTION
Refs gh-266. Fixed broken readme reference in the makefile and added the changelog to the tar-bundled distribution
