### PR TITLE
Clobbering styles on hover end for editor classes

### DIFF
--- a/src/wymeditor/plugins/hovertools/jquery.wymeditor.hovertools.js
+++ b/src/wymeditor/plugins/hovertools/jquery.wymeditor.hovertools.js
@@ -42,7 +42,7 @@ WYMeditor.editor.prototype.hovertools = function() {
             // Don't use jQuery.find() on the iframe body
             // because of MSIE + jQuery + expando issue (#JQ1143)
             if (!jQuery.browser.msie) {
-                jQuery(wym._doc).find('*').removeAttr('style');
+                jQuery(wym._doc).find('*').attr('style', '').removeAttr('style');
             }
         }
     );


### PR DESCRIPTION
Added blanking of style attribute for hovertools to force the removal of added styles, fixing an issue with Chrome.

The issue was that the green background added by hovering over classes would remain in the DOM, and be submitted with the form. This code would appear to be redundant, but the clobbering really does seem to help, and it should not have adverse affects for other browsers.
