### PR TITLE
Paste from word regression

### DIFF
--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -293,24 +293,65 @@ test("Shouldn't strip colSpan attributes", function () {
 
 module("Post Init", {setup: setupWym});
 
-if (!$.browser.msie || !SKIP_KNOWN_FAILING_TESTS) {
-    test("Commands: html(), paste()", function () {
-        expect(2);
-        var testText1 = '<p>This is some text with which to test.<\/p>';
-        var wymeditor = jQuery.wymeditors(0);
+test("Commands: html(), paste()", function () {
+    expect(2);
+    var testText1 = '<p>This is some text with which to test.<\/p>';
+    var wymeditor = jQuery.wymeditors(0);
 
-        wymeditor.html(testText1);
-        htmlEquals(wymeditor, testText1);
+    wymeditor.html(testText1);
+    htmlEquals(wymeditor, testText1);
 
-        var testText2 = 'Some <strong>other text<\/strong> with which to test.';
-        wymeditor._doc.body.focus();
-        wymeditor.paste(testText2);
+    var testText2 = 'Some <strong>other text<\/strong> with which to test.';
+    wymeditor._doc.body.focus();
+    wymeditor.paste(testText2);
 
-        // The pasted content should be wrapped in a paragraph
-        var expected = testText1 + '<p>' + testText2 + '<\/p>';
-        htmlEquals(wymeditor, expected);
-    });
-}
+    // The pasted content should be wrapped in a paragraph
+    var expected = testText1 + '<p>' + testText2 + '<\/p>';
+    htmlEquals(wymeditor, expected);
+});
+
+test("Paste from word", function () {
+    var textText,
+        wymeditor,
+        expected;
+
+    expect(1);
+    testText = 'sentence\r\n' +
+        'sentence2\r\n' +
+        '1.list1\r\n' +
+        '2.list2\r\n' +
+        '3.list3\r\n' +
+        'sentence3\r\n\r\n' +
+        'gap\r\n\r\n' +
+        'gap2';
+    if ($.browser !== 'msie') {
+        testText = testText.replace(/\r/g, '');
+
+    }
+    expectedHtml = String() +
+        '<p>' +
+        'sentence<br />' +
+        'sentence2<br />' +
+        '1.list1<br />' +
+        '2.list2<br />' +
+        '3.list3<br />' +
+        'sentence3' +
+        '</p>' +
+        '<p>' +
+        'gap' +
+        '</p>' +
+        '<p>' +
+        'gap2' +
+        '</p>';
+    wymeditor = jQuery.wymeditors(0);
+    wymeditor.html('');
+
+    wymeditor._doc.body.focus();
+    wymeditor.paste(testText);
+
+    // The pasted content should be wrapped in a paragraph
+    htmlEquals(wymeditor, expectedHtml);
+});
 
 if (!$.browser.msie || !SKIP_KNOWN_FAILING_TESTS) {
     test("Adding combined CSS selectors", function () {

--- a/src/wymeditor/core.js
+++ b/src/wymeditor/core.js
@@ -173,6 +173,7 @@ jQuery.extend(WYMeditor, {
     STATUS              : "{Wym_Status}",
     DIALOG_TITLE        : "{Wym_Dialog_Title}",
     DIALOG_BODY         : "{Wym_Dialog_Body}",
+    NEWLINE             : "\n",
     STRING              : "string",
     BODY                : "body",
     DIV                 : "div",

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -947,12 +947,12 @@ WYMeditor.editor.prototype.paste = function (str) {
         l;
 
     // Split string into paragraphs by two or more newlines
-    paragraphs = str.split(new RegExp(this._newLine + '{2,}', 'g'));
+    paragraphs = str.split(new RegExp(WYMeditor.NEWLINE + '{2,}', 'g'));
 
     // Build html
     for (i = 0, l = paragraphs.length; i < l; i += 1) {
         html += '<p>' +
-            (paragraphs[i].split(this._newLine).join('<br />')) +
+            (paragraphs[i].split(WYMeditor.NEWLINE).join('<br />')) +
             '</p>';
     }
 
@@ -968,7 +968,6 @@ WYMeditor.editor.prototype.paste = function (str) {
     }
 
     // Do some minor cleanup (#131)
-
     if (jQuery(container).text() === '') {
         jQuery(container).remove();
     }

--- a/src/wymeditor/editor/firefox.js
+++ b/src/wymeditor/editor/firefox.js
@@ -24,7 +24,6 @@
 WYMeditor.WymClassMozilla = function (wym) {
     this._wym = wym;
     this._class = "class";
-    this._newLine = "\n";
 };
 
 // Placeholder cell to allow content in TD cells for FF 3.5+

--- a/src/wymeditor/editor/ie.js
+++ b/src/wymeditor/editor/ie.js
@@ -23,7 +23,6 @@
 WYMeditor.WymClassExplorer = function (wym) {
     this._wym = wym;
     this._class = "className";
-    this._newLine = "\r\n";
 };
 
 WYMeditor.WymClassExplorer.PLACEHOLDER_NODE = '<br>';
@@ -324,43 +323,3 @@ WYMeditor.WymClassExplorer.prototype.spaceBlockingElements = function () {
     $body.find(blockSepSelector).before(placeholderNode);
 };
 
-/* @name paste
- * @description         Paste text into the editor below the carret,
- *                      used for "Paste from Word".
- * @param String str    String to insert, two or more newlines separates
- *                      paragraphs. May contain inline HTML.
- */
-WYMeditor.WymClassExplorer.prototype.paste = function (str) {
-    var container = this.selected(),
-        html = '',
-        paragraphs,
-        focusNode,
-        i;
-
-    // Insert where appropriate
-    if (container && container.tagName.toLowerCase() !== WYMeditor.BODY) {
-        // No .last() pre jQuery 1.4
-        //focusNode = jQuery(html).insertAfter(container).last()[0];
-        paragraphs = jQuery(container).append(str);
-        focusNode = paragraphs[paragraphs.length - 1];
-    } else {
-        // Split string into paragraphs by two or more newlines
-        paragraphs = str.split(new RegExp(this._newLine + '{2,}', 'g'));
-
-        // Build html
-        for (i = 0, l = paragraphs.length; i < l; i++) {
-            html += '<p>' +
-                (paragraphs[i].split(this._newLine).join('<br />')) +
-                '</p>';
-        }
-
-        paragraphs = jQuery(html, this._doc).appendTo(this._doc.body);
-        focusNode = paragraphs[paragraphs.length - 1];
-    }
-
-    // And remove br (if editor was empty)
-    jQuery('body > br', this._doc).remove();
-
-    // Restore focus
-    this.setFocusToNode(focusNode);
-};

--- a/src/wymeditor/editor/opera.js
+++ b/src/wymeditor/editor/opera.js
@@ -20,7 +20,6 @@
 WYMeditor.WymClassOpera = function(wym) {
     this._wym = wym;
     this._class = "class";
-    this._newLine = "\r\n";
 };
 
 WYMeditor.WymClassOpera.prototype.initIframe = function(iframe) {

--- a/src/wymeditor/editor/webkit.js
+++ b/src/wymeditor/editor/webkit.js
@@ -21,7 +21,6 @@
 WYMeditor.WymClassSafari = function(wym) {
     this._wym = wym;
     this._class = "class";
-    this._newLine = "\n";
 };
 
 WYMeditor.WymClassSafari.prototype.initIframe = function(iframe) {


### PR DESCRIPTION
Paste from word isn't properly splitting things on linebreaks in IE with 1.0.0a1. This was working properly in 0.5 and is a regression.
