### PR TITLE
Correct handling of <col /> in XHTML

### DIFF
--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -300,9 +300,9 @@ test("no-op on table with colgroup generates valid XHTML", function () {
     var tableWithColXHtml = String() +
         '<table>' +
             '<colgroup>' +
-                '<col width="20%"/>' +
-                '<col width="30%"/>' +
-                '<col width="50%"/>' +
+                '<col width="20%" />' +
+                '<col width="30%" />' +
+                '<col width="50%" />' +
             '</colgroup>' +
             '<tbody>' +
                 '<tr id="tr_1">' +

--- a/src/wymeditor/parser/xhtml-sax-listener.js
+++ b/src/wymeditor/parser/xhtml-sax-listener.js
@@ -99,7 +99,7 @@ WYMeditor.XhtmlSaxListener = function() {
     this.block_tags = [
         "a", "abbr", "acronym", "address", "area", "b",
         "base", "bdo", "big", "blockquote", "body", "button",
-        "caption", "cite", "code", "col", "colgroup", "dd", "del", "div",
+        "caption", "cite", "code", "colgroup", "dd", "del", "div",
         "dfn", "dl", "dt", "em", "fieldset", "form", "head", "h1", "h2",
         "h3", "h4", "h5", "h6", "html", "i", "ins",
         "kbd", "label", "legend", "li", "map", "noscript",
@@ -109,7 +109,7 @@ WYMeditor.XhtmlSaxListener = function() {
         "thead", "title", "tr", "tt", "ul", "var", "extends"];
 
 
-    this.inline_tags = ["br", "hr", "img", "input"];
+    this.inline_tags = ["br", "col", "hr", "img", "input"];
 
     return this;
 };


### PR DESCRIPTION
<col />-elements are self-closing in XHTML. Prior to this change, the WYMEditor failed to close the elements, and generated invalid XHTML if the initial XHTML contained these elements.

A test case is included.
