### PR TITLE
Bugfix: A missing space made it unusable in non-quirks mode.

### DIFF
--- a/src/wymeditor/core.js
+++ b/src/wymeditor/core.js
@@ -418,7 +418,7 @@ jQuery.fn.wymeditor = function (options) {
 
         toolsItemHtml: String() +
             '<li class="' + WYMeditor.TOOL_CLASS + '">' +
-                '<a href="#" name="' + WYMeditor.TOOL_NAME + '"' +
+                '<a href="#" name="' + WYMeditor.TOOL_NAME + '" ' +
                         'title="' + WYMeditor.TOOL_TITLE + '">' +
                     WYMeditor.TOOL_TITLE +
                 '</a>' +


### PR DESCRIPTION
Bug actually observed in Firefox 10.0.1. Adding this space made it work (or enforcing quirks mode).
