### PR TITLE
DIV created after exiting an UL/OL via double enter keypress

### DIFF
--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -742,6 +742,7 @@ WYMeditor.editor.prototype.update = function () {
 WYMeditor.editor.prototype.fixBodyHtml = function () {
     this.fixDoubleBr();
     this.spaceBlockingElements();
+    this.fixCurrentDiv();
 };
 
 /**
@@ -841,6 +842,20 @@ WYMeditor.editor.prototype.fixDoubleBr = function () {
         }
     }
 };
+
+/**
+    editor.fixCurrentDiv
+    ====================
+
+    If the caret is currently on a DIV node, for whatever reason,
+    change it into a P. FIXME: DIVs shouldn't be created at all in
+    the first place.
+*/
+WYMeditor.editor.prototype.fixCurrentDiv = function () {
+    var node = this.selected();
+    if (node && node.tagName.toLowerCase() === 'div')
+      this.switchTo(node, 'P');
+}
 
 /**
     editor.dialog


### PR DESCRIPTION
Hi,

On Chrome 22, Internet Explorer 8 and 9, if you create an (un)ordered list and then hit "enter" twice, you correctly close the list, but the cursor ends up being into an empty "div"; and no `.container()` call can reset it to a `P`.

In the attached commit there is an hacky and wrong solution that uses `.fixBodyHtml()` as invoked from the `keyup` handler.

What is instead the correct way of handling this, in your opinion?

Thanks.
