### PR TITLE
Fix reference in example

### DIFF
--- a/src/examples/12-custom-layout.html
+++ b/src/examples/12-custom-layout.html
@@ -83,7 +83,7 @@ jQuery(function() {
             .css("width", "140px");
 
         //add a ">" character to the title of the new dropdown menus (visual cue)
-        jQuery(this._box).find(".wym_tools, .wym_classes ")
+        jQuery(wym._box).find(".wym_tools, .wym_classes ")
             .find(WYMeditor.H2)
             .append("<span>&nbsp;&gt;</span>");
         }


### PR DESCRIPTION
Tools and classes dropdowns were not being decorated due to bad reference
