### PR TITLE
Fix issue with two not-quite JSdoc comments

### DIFF
--- a/src/wymeditor/editor/firefox.js
+++ b/src/wymeditor/editor/firefox.js
@@ -91,7 +91,7 @@ WYMeditor.WymClassMozilla.prototype.initIframe = function (iframe) {
     this.listen();
 };
 
-/* @name html
+/** @name html
  * @description Get/Set the html value
  */
 WYMeditor.WymClassMozilla.prototype.html = function (html) {

--- a/src/wymeditor/editor/ie.js
+++ b/src/wymeditor/editor/ie.js
@@ -281,7 +281,7 @@ WYMeditor.WymClassExplorer.prototype.setFocusToNode = function (node, toStart) {
     node.focus();
 };
 
-/* @name spaceBlockingElements
+/** @name spaceBlockingElements
  * @description Insert <br> elements between adjacent blocking elements and
  * p elements, between block elements or blocking elements and after blocking
  * elements.


### PR DESCRIPTION
When trying to build wymeditor with Google's Closure Compiler, two warnings were reported:

```
dist/jquery.wymeditor.js:7304: WARNING - Parse error. Non-JSDoc comment has  annotations. Did you mean to start it with '/**'?
/* @name spaceBlockingElements
^

dist/jquery.wymeditor.js:7430: WARNING - Parse error. Non-JSDoc comment has annotations. Did you mean to start it with '/**'?
/* @name html
^
```

This patch fixes the issue.
