### PR TITLE
Fix selection so it works in IE8+9 without forced compat mode.

### DIFF
--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -394,15 +394,16 @@ WYMeditor.editor.prototype.selected = function () {
 
     if (node) {
         if (jQuery.browser.msie) {
-            if (sel.isCollapsed && node.tagName && node.tagName.toLowerCase() === 'body') {
-                // For collapsed selections, we have to use the ghetto "caretPos"
-                // hack to find the selection, otherwise it always says that the
-                // body element is selected
+            // For collapsed selections, we have to use the ghetto "caretPos"
+            // hack to find the selection, otherwise it always says that the
+            // body element is selected
+            var isBodyTag = node.tagName && node.tagName.toLowerCase() === "body";
+            var isTextNode = node.nodeName === "#text";
+
+            if (sel.isCollapsed && (isBodyTag || isTextNode)) {
                 caretPos = this._iframe.contentWindow.document.caretPos;
-                if (caretPos) {
-                    if (caretPos.parentElement) {
-                        node = caretPos.parentElement();
-                    }
+                if (caretPos && caretPos.parentElement) {
+                    node = caretPos.parentElement();
                 }
             }
         }

--- a/src/wymeditor/iframe/default/wymiframe.html
+++ b/src/wymeditor/iframe/default/wymiframe.html
@@ -19,7 +19,6 @@
 <html>
 <head>
 <title>WYMeditor iframe</title>
-<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
 <link rel="stylesheet" type="text/css" media="screen" href="wymiframe.css" />
 </head>
 <body class="wym_iframe"></body>


### PR DESCRIPTION
Hey Wes,

I've fixed the issue with flickering in IE8 by removing the IE7 header in the iframe. As you mentioned this change broke the table plugin. 

After investigating it had to do with how it was determining the selectednode via

``` javascript
WYMeditor.editor.prototype.selected
```

This should now work in IE8/9.

On a side note master branch has failing tests in IE8/9 (and this change results in the same failures).
- IE8 has 12 failures
- IE9 has 22 failures

Probably we should figure out why so we can have passing tests on all new code.

Tested on: FF, Chrome, IE8/9 (with failures mentioned above) 

Thanks,

Craig
