### PR TITLE
use greater-than syntax rather than tilde

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-b6",
   "dependencies": {
     "requirejs": "~2.1.4",
-    "jquery": "~1.4.4"
+    "jquery": ">1.4.4"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
the tilde is overly specific and ends up causing conflicts with other dependencies that depend on jQuery. the greater-than allows any version 1.4.4 or newer to match bower's conflict resolution
