### PR TITLE
Do we need a `tbody`-existence test?

### DIFF
--- a/src/test/unit/specific_feature_tests/lists.js
+++ b/src/test/unit/specific_feature_tests/lists.js
@@ -799,7 +799,7 @@ var nodeContentAfterSublistHtml = String() +
                     '<li id="li_1_1">1_1</li>' +
                     '<li id="li_1_2">1_2</li>' +
                 '</ul>' +
-                '<table><tr><td>td_1_3</td></tr></table>' +
+                '<table><tbody><tr><td>td_1_3</td></tr></tbody></table>' +
             '</li>' +
             '<li id="li_2">2</li>' +
         '</ol>';
@@ -1004,7 +1004,7 @@ module("list-invalid_nesting", {setup: setupWym});
 
 var invalidNestingNoPreviousHtml = String() +
         '<ol>' +
-            '<table id="table_1"><tr><td>td_1_1</td></tr></table>' +
+            '<table id="table_1"><tbody><tr><td>td_1_1</td></tr></tbody></table>' +
             '<ul>' +
                 '<li id="li_2_1">2_1' +
                     '<ul>' +
@@ -1019,7 +1019,7 @@ var invalidNestingNoPreviousHtml = String() +
             '<li id="li_4">4</li>' +
             'text_5_1<span id="span_5_2">5_2</span>text_5_3' +
             '<li id="li_6">6</li>' +
-            '<table id="table_7"><tr><td>td_7_1</td></tr></table>' +
+            '<table id="table_7"><tbody><tr><td>td_7_1</td></tr></tbody></table>' +
             '<ol>' +
                 '<li id="li_8">8</li>' +
             '</ol>' +


### PR DESCRIPTION
I set up this branch to examine whether it is required that there be a test that checks whether a `tbody` element is added in the editor and in the parsed output, `.xhtml()`.

I've come to the conclusion that since all our tests with tables expect the existence of a `tbody` element, if ever this was not supplied, it would fail dozens of tests.

Another reason that this is not required is that the `tbody` is added in the DOM of the browser automatically, even if not supplied. I guess that this is how all browsers behave.

I did find a few tests that were missing the `tbody` element in their HTML strings. So this is worth a merge.
