### PR TITLE
Empty textarea is empty

### DIFF
--- a/src/test/unit/specific_feature_tests/xml_parser.js
+++ b/src/test/unit/specific_feature_tests/xml_parser.js
@@ -8,8 +8,14 @@ module("XmlParser", {setup: setupWym});
 
 test("Empty is empty", function () {
     var wymeditor = jQuery.wymeditors(0);
+    expect(2);
 
     wymeditor._html('');
+    wymEqual(wymeditor, '');
+
+    wymeditor._html('');
+    // Placing the caret inside shouldn't create any content.
+    wymeditor.setCaretIn(jQuery(wymeditor._doc).find('body.wym_iframe')[0]);
     wymEqual(wymeditor, '');
 });
 


### PR DESCRIPTION
Using version 1.0.0b5, and the first example (01-basic - adding a name to the textarea so that we can see what is submitted, and setting the `textarea` content to nothing), we see that on submit, WymEditor automatically sets the value of the `textarea` to `<br />`.
In my opinion this is a bug - empty content should be just that - empty.
