### PR TITLE
Bowerize HTML beautifier dependency

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -3,7 +3,6 @@ node_modules
 src/jquery/*
 src/test/unit/qunit/*
 src/test/unit/sinon/*
-src/test/unit/beautify-html.js
 src/wymeditor/editor/opera.js
 src/wymeditor/lang/*
 src/wymeditor/rangy/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -363,7 +363,15 @@ module.exports = function (grunt) {
                     cwd: 'src',
                     force: false,
                     map: {
-                        '*': '/'
+                        'require.js': '/',
+                        'jquery.js': '/',
+                        'jquery.browser.js': '/',
+                        // Originates from js-beautify
+                        'beautify-html.js': '/',
+                        // following two also originate from js-beautify and we
+                        // don't use them so tuck them away nicely.
+                        'beautify.js': '/redundant/',
+                        'beautify-css.js': '/redundant/'
                     },
                     offline: true,
                     root: "<%= yeoman.app %>/lib",

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,9 @@
     "jquery": "~1.4.4",
     "jquery.browser": "~0.0.6"
   },
-  "devDependencies": {},
+  "devDependencies": {
+      "js-beautify": "https://github.com/beautify-web/js-beautify.git#1.5"
+  },
   "resolutions": {
     "jquery": "~1.4.4"
   }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "grunt-replace": "~0.4.4",
     "grunt-rev": "~0.1.0",
     "grunt-usemin": "~0.1.10",
-    "js-beautify": "~1.5.1",
     "time-grunt": "~0.1.1"
   },
   "engines": {

--- a/src/test/unit/beautify-html.js
+++ b/src/test/unit/beautify-html.js
@@ -1,1 +1,0 @@
-../../../node_modules/js-beautify/js/lib/beautify-html.js

--- a/src/test/unit/index.html
+++ b/src/test/unit/index.html
@@ -49,7 +49,7 @@
             "sinon/sinon-qunit-1.0.0.js",
 
             // An HTML beautifier
-            "beautify-html.js",
+            "../../lib/beautify-html.js",
 
             // Test files
             "utils.js",


### PR DESCRIPTION
We either need to commit `beautify-html.js` to our repo or use bower to install it and grunt to move it to the right spot. We can't just do a symlink because that breaks our website build.

```
The page build failed with the following error:

The symbolic link `/src/test/unit/beautify-html.js` targets a file which does not exist within your site's repository. For more information, see https://help.github.com/articles/page-build-failed-symlink-does-not-exist-within-your-site-s-repository.
```
