### PR TITLE
Remove redundant `grunt-contrib-htmlmin`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,28 +162,6 @@ module.exports = function (grunt) {
                 '<%= yeoman.dist %>/wymeditor/skins/{,*/}*.css'
             ]
         },
-        htmlmin: {
-            dist: {
-                options: {
-                    /*removeCommentsFromCDATA: true,
-                    // https://github.com/yeoman/grunt-usemin/issues/44
-                    //collapseWhitespace: true,
-                    collapseBooleanAttributes: true,
-                    removeAttributeQuotes: true,
-                    removeRedundantAttributes: true,
-                    useShortDoctype: true,
-                    removeEmptyAttributes: true,
-                    removeOptionalTags: true*/
-                    keepClosingSlash: true
-                },
-                files: [{
-                    expand: true,
-                    cwd: '<%= yeoman.app %>',
-                    src: 'wymeditor/iframe/{,*/}*.html',
-                    dest: '<%= yeoman.dist %>'
-                }]
-            }
-        },
         replace: {
             dist: {
                 options: {
@@ -427,7 +405,6 @@ module.exports = function (grunt) {
         grunt.task.run([
             'bower',
             'clean:server',
-            'htmlmin',
             'connect:dev',
             'watch:default'
         ]);
@@ -485,7 +462,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-clean");
     grunt.loadNpmTasks("grunt-contrib-qunit");
     grunt.loadNpmTasks("grunt-replace");
-    grunt.loadNpmTasks("grunt-contrib-htmlmin");
     grunt.loadNpmTasks("grunt-usemin");
     grunt.loadNpmTasks("grunt-bower-install-simple");
     grunt.loadNpmTasks('grunt-bower-linker');

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "grunt-contrib-csslint": "~0.1.2",
     "grunt-contrib-cssmin": "~0.6.1",
     "grunt-contrib-handlebars": "~0.5.9",
-    "grunt-contrib-htmlmin": "~0.1.3",
     "grunt-contrib-imagemin": "~0.1.4",
     "grunt-contrib-jshint": "0.9.2",
     "grunt-contrib-jst": "~0.5.0",


### PR DESCRIPTION
I'm kind of guessing but I think that this is why we have changed iframes after `$ grunt server`.
