### PR TITLE
Chrome (37) throws error in WYMeditor.editor.prototype._isPOrDivAfterEnterInEmptynestedLi

### DIFF
--- a/src/wymeditor/editor/webkit.js
+++ b/src/wymeditor/editor/webkit.js
@@ -273,11 +273,14 @@ WYMeditor.WymClassWebKit.prototype.keyup = function (evt) {
         if (jQuery.inArray(name, notValidRootContainers) > -1 &&
                 parentName === WYMeditor.BODY) {
             wym._exec(WYMeditor.FORMAT_BLOCK, defaultRootContainer);
+            container = wym.selectedContainer();
         }
 
         // Issue #542
         if (wym._isLiInLiAfterEnter(evt.which, container)) {
             wym._fixLiInLiAfterEnter();
+            // Container may have changed.
+            container = wym.selectedContainer();
             return;
         }
 


### PR DESCRIPTION
Reproduce:
Visit src/test/advanced.html in your browser. Click in the list container of the first sample WYM editor.  Press enter twice to create a new container.  Error in console: `Uncaught TypeError: Cannot read property 'tagName' of null`

See line 2400 of base.js
