### PR TITLE
Fix bower dependency declaration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "editor"
   ],
   "dependencies": {
-    "jquery": "1.4.4 - ~1.11.1"
+    "jquery": "1.4.4 - 1.11"
   },
   "devDependencies": {
     "requirejs": "~2.1",


### PR DESCRIPTION
Currently bower is unable to install wymeditor because tilde range is declared in the hyphen range, which cannot be parsed.
