### PR TITLE
Add selection to initial undo point on focus

### DIFF
--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1442,9 +1442,6 @@ WYMeditor.editor.prototype.getCurrentState = function () {
         state.savedSelection = rangy.saveSelection(wymIframeWindow);
     }
 
-    selection = wym.selection();
-
-
     state.html = wym.rawHtml();
 
     if (state.savedSelection) {

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1424,11 +1424,26 @@ WYMeditor.editor.prototype.getCurrentState = function () {
         selection,
         wymIframeWindow = wym._iframe.contentWindow;
 
-    selection = wym.selection();
+    if (wym.hasSelection()) {
+        selection = wym.selection();
+    }
 
-    if (wym.hasSelection() === true) {
+    if (
+        selection &&
+        selection.anchorNode === wym.body() &&
+        selection.anchorOffset === 0 &&
+        selection.isCollapsed
+    ) {
+        // meaningless selection
+        selection = false;
+    }
+
+    if (selection) {
         state.savedSelection = rangy.saveSelection(wymIframeWindow);
     }
+
+    selection = wym.selection();
+
 
     state.html = wym.rawHtml();
 

--- a/src/wymeditor/editor/gecko.js
+++ b/src/wymeditor/editor/gecko.js
@@ -26,6 +26,9 @@ WYMeditor.WymClassGecko.prototype._docEventQuirks = function () {
     jQuery(wym._doc).bind("click", function (evt) {
         wym._click(evt);
     });
+    jQuery(wym._doc).bind("focus", function () {
+        wym.undoRedo._onBodyFocus();
+    });
 };
 
 // Keyup handler, mainly used for cleanups

--- a/src/wymeditor/editor/trident-7.js
+++ b/src/wymeditor/editor/trident-7.js
@@ -61,4 +61,8 @@ WYMeditor.WymClassTrident7.prototype._docEventQuirks = function () {
             wym.deselect();
         }
     });
+
+    wym.$body().bind("focus", function () {
+        wym.undoRedo._onBodyFocus();
+    });
 };

--- a/src/wymeditor/editor/trident-pre-7.js
+++ b/src/wymeditor/editor/trident-pre-7.js
@@ -43,6 +43,10 @@ WYMeditor.WymClassTridentPre7.prototype._docEventQuirks = function () {
         wym._saveCaret();
     };
 
+    wym.$body().bind("focus", function () {
+        wym.undoRedo._onBodyFocus();
+    });
+
     wym._doc.body.onbeforepaste = function () {
         wym._iframe.contentWindow.event.returnValue = false;
     };

--- a/src/wymeditor/editor/undo-redo.js
+++ b/src/wymeditor/editor/undo-redo.js
@@ -45,6 +45,38 @@ WYMeditor.UndoRedo = function (wym) {
 };
 
 /**
+    WYMeditor.UndoRedo._onBodyFocus
+    ===============================
+
+    This method is called on focus of the document's body.
+
+    If the last saved history point does not include a saved selection
+    then the last saved history point is replaced with the current state,
+    which does include a selection.
+
+    When this method is called by the triggering of the focus event,
+    the selection is not yet made.
+
+    Hence the use of `setTimeout`--the function provided to `setTimeout`
+    will always be called after the event's native action. By that time
+    there should be a selection.
+*/
+WYMeditor.UndoRedo.prototype._onBodyFocus = function () {
+    var undoRedo = this,
+        wym = undoRedo.wym;
+
+    if (undoRedo.history.last.savedSelection) {
+        // last history point has selection
+        return;
+    }
+
+    setTimeout(function () {
+        // this will run after the native action of the triggering event.
+        undoRedo.history.last = wym.getCurrentState();
+    }, 0);
+};
+
+/**
     WYMeditor.UndoRedo._add
     =======================
 

--- a/src/wymeditor/editor/webkit.js
+++ b/src/wymeditor/editor/webkit.js
@@ -23,6 +23,10 @@ WYMeditor.WymClassWebKit.prototype._docEventQuirks = function () {
             return false;
         }
     );
+
+    wym.$body().bind("focus", function () {
+        wym.undoRedo._onBodyFocus();
+    });
 };
 
 // A `div` can be created by breaking out of a list in some cases. Issue #549.


### PR DESCRIPTION
The first history point is saved on initialization. It is saved without selection because at that time there can be no selection.

```js
var onFocus = function () {
  if (
    thereIsOnlyOneUndoPoint &&
    thatUndoPointDoesntHaveSelection &&
    currentStateHtml === thatUndoPointHtml
  ) {
  history.reset()
  undoRedo.add()
  }
}
```

https://trello.com/c/TfpuohAf/5-properly-set-selection-at-initial-history-point