### PR TITLE
Exception parsing HTML with regex special chars in an attribute

### DIFF
--- a/src/test/unit/specific_feature_tests/xml_parser.js
+++ b/src/test/unit/specific_feature_tests/xml_parser.js
@@ -2409,6 +2409,15 @@ test("Three `br` variations without `id`s", function () {
     }
 });
 
+var attributeWithRegexCharHTML = String() + '<a href="http://www.example.com)">Foo</a>';
+
+test("Attributes with REGEX chars do not break parsing", function () {
+    QUnit.expect(1);
+    var wymeditor = jQuery.wymeditors(0);
+
+    deepEqual(wymeditor.parser.parse(attributeWithRegexCharHTML), attributeWithRegexCharHTML);
+});
+
 module("XmlParser-auto_close_tags", {setup: prepareUnitTestModule});
 
 var nestedTableHtml = String() +

--- a/src/wymeditor/parser/xhtml-sax-listener.js
+++ b/src/wymeditor/parser/xhtml-sax-listener.js
@@ -386,8 +386,7 @@ WYMeditor.XhtmlSaxListener.prototype.openBlockTag = function(tag, attributes) {
         this._addSpacerBeforeElementInLI = false;
     }
 
-    this._lastAddedOpeningTagString = this.helper.tag(tag, attributes, true);
-    this.output += this._lastAddedOpeningTagString
+    this.output += this.helper.tag(tag, attributes, true);
     this._lastAddedOpenTag = tag;
     this._lastTagRemoved = false;
 };
@@ -430,16 +429,6 @@ WYMeditor.XhtmlSaxListener.prototype.closeBlockTag = function(tag) {
     if (jQuery.inArray(tag, WYMeditor.LIST_TYPE_ELEMENTS) > -1) {
         this._insideLI = false;
     }
-
-    // If a `br` is the only tag within the element that is being closed,
-    // remove that `br` tag.
-    this.output = this.output.replace(
-        new RegExp(
-            this._lastAddedOpeningTagString + '<br />$',
-            ''
-        ),
-        this._lastAddedOpeningTagString
-    );
 
     this.output = this.output +
         this._getClosingTagContent('before', tag) +


### PR DESCRIPTION
A specific piece of HTML is causing the parser to throw an error in v1.0.0-rc.2 that doesn't throw an error in v1.0.0-b6. Working on a minimal reproduction.

### Triggering HTML

```html
<a href="http://www.example.com)">Foo</a>
```

### Traceback

```
Uncaught SyntaxError: Invalid regular expression: /<a href="http://www.example.com)"><br />$/: Unmatched ')'
xhtml-sax-listener.js:437 
WYMeditor.XhtmlSaxListener.closeBlockTagxhtml-parser.js:161
WYMeditor.XhtmlParser._callCloseTagListenerxhtml-parser.js:118
WYMeditor.XhtmlParser.ClosingTaglexer.js:269
WYMeditor.Lexer._invokeParserlexer.js:209
WYMeditor.Lexer._dispatchTokenslexer.js:160
WYMeditor.Lexer.parsexhtml-parser.js:22
WYMeditor.XhtmlParser.parsebase.js:653
WYMeditor.editor.htmlbase.js:1538
WYMeditor.editor.updatebase.js:675
WYMeditor.editor.execbase.js:451
(anonymous function)jquery.js:2260 jQuery.event.handlejquery.js:1891 jQuery.event.add.elemData.handle.eventHandle
```

[this line](https://github.com/wymeditor/wymeditor/blob/master/src/wymeditor/parser/xhtml-sax-listener.js#L442) is throwing that SyntaxError:
```javascript
    // If a `br` is the only tag within the element that is being closed,
    // remove that `br` tag.
    this.output = this.output.replace(
        new RegExp(
            this._lastAddedOpeningTagString + '<br />$',
            ''
        ),
        this._lastAddedOpeningTagString
    );
```