### PR TITLE
Popups in IE need to load a document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ WYMeditor.
 * [#730](https://github.com/wymeditor/wymeditor/pull/730)
   ``.insert()`` in IE8-10 when no selection would
   paste at top of document
+* [#731](https://github.com/wymeditor/wymeditor/pull/731)
+  Depending on their security configuration,
+  IEs could make popups entirely useless.
 
 ## 1.0.0
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -360,6 +360,13 @@ module.exports = function (grunt) {
                             "iframe/{,*/}*.{html,js,css,png,jpg,jpeg,gif,eot,ttf,woff}"
                         ]
                     },
+                    // Popup document
+                    // https://github.com/wymeditor/wymeditor/issues/731
+                    {
+                        cwd: '<%= yeoman.app %>/wymeditor',
+                        dest: '<%= yeoman.dist %>/wymeditor',
+                        src: "popup.html"
+                    },
                     // Non-Javascript skin components
                     // The javascript is included in jquery.wymeditor.js
                     {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -363,9 +363,8 @@ module.exports = function (grunt) {
                     // Popup document
                     // https://github.com/wymeditor/wymeditor/issues/731
                     {
-                        cwd: '<%= yeoman.app %>/wymeditor',
-                        dest: '<%= yeoman.dist %>/wymeditor',
-                        src: "popup.html"
+                        dest: '<%= yeoman.dist %>/wymeditor/popup.html',
+                        src: '<%= yeoman.app %>/wymeditor/popup.html'
                     },
                     // Non-Javascript skin components
                     // The javascript is included in jquery.wymeditor.js

--- a/src/wymeditor/core.js
+++ b/src/wymeditor/core.js
@@ -936,7 +936,7 @@ WYMeditor._computeWymPath = function () {
     the wymeditor base file. This path is used as the basis for loading:
     * Language files
     * Skins
-    *
+    * The popup document https://github.com/wymeditor/wymeditor/issues/731
 */
 WYMeditor._computeBasePath = function (wymPath) {
     // Strip everything after the last slash to get the base path

--- a/src/wymeditor/editor/dialogs.js
+++ b/src/wymeditor/editor/dialogs.js
@@ -1,5 +1,26 @@
 "use strict";
 /**
+    editor._openPopupWindow
+    =======================
+
+    Opens a popup window, provided the `windowFeatures`.
+*/
+WYMeditor.editor.prototype._openPopupWindow = function (windowFeatures) {
+    var wym = this,
+        popup,
+        basePath = wym._options.basePath;
+
+    popup = window.open(
+        // https://github.com/wymeditor/wymeditor/issues/731
+        jQuery.browser.msie ? basePath + 'popup.html' : '',
+        "wymPopupWindow",
+        windowFeatures
+    );
+
+    return popup;
+}
+
+/**
     editor.dialog
     =============
 
@@ -86,11 +107,7 @@ WYMeditor.editor.prototype.dialog = function (
         ].join(",");
     }
 
-    wDialog = window.open(
-        '',
-        "wymDialogWindow",
-        dialogWindowFeatures
-    );
+    wDialog = wym._openPopupWindow(dialogWindowFeatures)
 
     if (
         typeof wDialog !== "object" ||

--- a/src/wymeditor/editor/dialogs.js
+++ b/src/wymeditor/editor/dialogs.js
@@ -18,7 +18,7 @@ WYMeditor.editor.prototype._openPopupWindow = function (windowFeatures) {
     );
 
     return popup;
-}
+};
 
 /**
     editor.dialog
@@ -107,7 +107,7 @@ WYMeditor.editor.prototype.dialog = function (
         ].join(",");
     }
 
-    wDialog = wym._openPopupWindow(dialogWindowFeatures)
+    wDialog = wym._openPopupWindow(dialogWindowFeatures);
 
     if (
         typeof wDialog !== "object" ||

--- a/src/wymeditor/popup.html
+++ b/src/wymeditor/popup.html
@@ -1,0 +1,1 @@
+<!-- Workaround for IE https://github.com/wymeditor/wymeditor/issues/731 -->


### PR DESCRIPTION
If `window.open` in IE does not load a document,
the parent window may not be allowed to control the child,
due to some "same-origin domain policy" security issue.

This results in entirely unusable popup windows.

This may be the cause of the following from the customer support room:
![screenshot_2015-08-15_01-53-35](https://cloud.githubusercontent.com/assets/635591/9285635/83876502-42f0-11e5-89b4-2baadc24a117.png)
