### PR TITLE
Hard code seamless skin height strategy in IE<11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ WYMeditor.
 
 *release-date* TBD
 
+* [#735](https://github.com/wymeditor/wymeditor/issues/735)
+  Seamless skin: iframe height might not be resized in IE<11
+
 ## 1.0.1
 
 *release-date* August 15 2015

--- a/src/wymeditor/skins/seamless/skin.js
+++ b/src/wymeditor/skins/seamless/skin.js
@@ -395,7 +395,23 @@ WYMeditor.SKINS.seamless = {
         htmlElementHeight = $htmlElement.height();
         htmlElementScrollHeight = $htmlElement[0].scrollHeight;
 
-        if (htmlElementHeight >= bodyScrollHeight) {
+        if (WYMeditor.isInternetExplorerPre11()) {
+            // The htmlElementScrollHeight is fairly reliable,
+            // but doesn't shrink when content is removed.
+            heightStrategy = function (wym) {
+                var $htmlElement = jQuery(wym._doc).children().eq(0),
+                    htmlElementScrollHeight = $htmlElement[0].scrollHeight;
+
+                // Without the 10px reduction in height, every possible action
+                // adds 10 pixels of height.
+                // TODO: Figure out why this happens and if we can make the
+                // 10px number not magic (actually derived from a
+                // margin/padding etc).
+                return htmlElementScrollHeight - 10;
+            };
+
+            return heightStrategy;
+        } else if (htmlElementHeight >= bodyScrollHeight) {
             // Well-behaving browsers like FF and Chrome let us rely on the
             // HTML element's jQuery height() in every case. Hooray!
             heightStrategy = function (wym) {
@@ -415,21 +431,7 @@ WYMeditor.SKINS.seamless = {
 
             return heightStrategy;
         } else {
-            // This is probably IE8+, where the htmlElementScrollHeight is
-            // fairly reliable, but doesn't shrink when content is removed.
-            heightStrategy = function (wym) {
-                var $htmlElement = jQuery(wym._doc).children().eq(0),
-                    htmlElementScrollHeight = $htmlElement[0].scrollHeight;
-
-                // Without the 10px reduction in height, every possible action
-                // adds 10 pixels of height.
-                // TODO: Figure out why this happens and if we can make the
-                // 10px number not magic (actually derived from a
-                // margin/padding etc).
-                return htmlElementScrollHeight - 10;
-            };
-
-            return heightStrategy;
+            throw new Error('unsupported browser');
         }
     },
     resizeIframe: function (wym) {


### PR DESCRIPTION
In the examples there is no issue.

In a specific integration, in IE<11, the height strategy for Chrome/FF is chosen, instead of the IE<11 strategy.

It seems more reliable to hard-code the strategy to the browser version, than the logic we currently have in place.