### PR TITLE
Selection across table cells broken in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ WYMeditor.
 
 *release-date* TBD
 
+* [#739](https://github.com/wymeditor/wymeditor/issues/739)
+  Fix selection across table cells in Firefox
+
 ## 1.0.4
 
 *release-date* August 28 2015

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -3018,7 +3018,10 @@ WYMeditor.editor.prototype._getSelectedNodes = function () {
         return false;
     }
 
-    selectedNodes = selection.getRangeAt(0).getNodes();
+    selectedNodes = selection.getAllRanges()
+        .reduce(function(nodes, range) {
+            return nodes.concat(range.getNodes());
+        }, [])
     return selectedNodes;
 };
 

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -3019,9 +3019,9 @@ WYMeditor.editor.prototype._getSelectedNodes = function () {
     }
 
     selectedNodes = selection.getAllRanges()
-        .reduce(function(nodes, range) {
+        .reduce(function (nodes, range) {
             return nodes.concat(range.getNodes());
-        }, [])
+        }, []);
     return selectedNodes;
 };
 


### PR DESCRIPTION
[Here](https://github.com/wymeditor/wymeditor/blob/1b072bb3f86c925cbf9ca4dfd8a2004613fc374f/src/wymeditor/editor/base.js#L3021) in firefox, we get only a partial array of nodes. We do not get the entire expected selection, as is shown in GUI.

We get only the selected nodes from the logically first, selected table cell.