### PR TITLE
Fix dist's license string

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,7 @@ module.exports = function (grunt) {
                 "Home page: <%= pkg.homepage %>\n\n" +
                 "Copyright (c) <%= grunt.template.today('yyyy') %> " +
                 "<%= pkg.author.name %>;\n" +
-                "Licensed <%= _.pluck(pkg.licenses, 'type').join(', ') %>\n" +
+                "Licensed <%= pkg.license %>\n" +
                 "*/\n\n"
         },
         // Some targets run concurrently because watch is blocking and we


### PR DESCRIPTION
This was broken in #740. This is the difference it makes (top of dist file):
![screenshot_2015-09-22_21-38-24](https://cloud.githubusercontent.com/assets/635591/10027943/5c6d9928-6172-11e5-99f2-2fd8e1d00e6f.png)

Without this change, it shows
```
Licenced 
```
(no license is shown).