### PR TITLE
Allow insert image and paste dialogs to open when selection is non-collapsed (not only when it is collapsed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ WYMeditor.
 
 *release-date* TBD
 
+* [#754] (https://github.com/wymeditor/wymeditor/issues/754)
+  Allow insert image and paste dialogs to open
+  when selection is non-collapsed (not only when it is collapsed)
 * [#747](https://github.com/wymeditor/wymeditor/pull/747)
   New: Image resizing
 

--- a/src/test/unit/specific_feature_tests/dialogs.js
+++ b/src/test/unit/specific_feature_tests/dialogs.js
@@ -265,7 +265,7 @@ test("Image dialog doesn't open when no selection", function () {
     });
 });
 
-test("Image dialog doesn't open when selection is non-collapsed", function () {
+test("Image dialog opens when selection is non-collapsed", function () {
     tryDialogWithClickAndKeyboardThenAssert({
         dialogName: "InsertImage",
         currentTest: this,
@@ -280,7 +280,7 @@ test("Image dialog doesn't open when selection is non-collapsed", function () {
                 3
             );
         },
-        expectedOpenedOrNot: DIALOG_EXPECT_NOT_OPENED
+        expectedOpenedOrNot: DIALOG_EXPECT_OPENED
     });
 });
 
@@ -348,7 +348,7 @@ test("Paste dialog doesn't open when no selection", function () {
     });
 });
 
-test("Paste dialog doesn't open when selection is non-collapsed", function () {
+test("Paste dialog opens when selection is non-collapsed", function () {
     tryDialogWithClickAndKeyboardThenAssert({
         dialogName: "Paste",
         currentTest: this,
@@ -363,7 +363,7 @@ test("Paste dialog doesn't open when selection is non-collapsed", function () {
                 3
             );
         },
-        expectedOpenedOrNot: DIALOG_EXPECT_NOT_OPENED
+        expectedOpenedOrNot: DIALOG_EXPECT_OPENED
     });
 });
 

--- a/src/wymeditor/editor/dialogs.js
+++ b/src/wymeditor/editor/dialogs.js
@@ -323,13 +323,7 @@ WYMeditor.DIALOGS = {
             ) {
                 return true;
             }
-            if (
-                wym.hasSelection() !== true ||
-                wym.selection().isCollapsed !== true
-            ) {
-                return false;
-            }
-            return true;
+            return wym.hasSelection();
         },
         getBodyHtml: function () {
             var wym = this;
@@ -488,13 +482,7 @@ WYMeditor.DIALOGS = {
         title: "Paste_From_Word",
         shouldOpen: function () {
             var wym = this;
-            if (
-                wym.hasSelection() !== true ||
-                wym.selection().isCollapsed !== true
-            ) {
-                return false;
-            }
-            return true;
+            return wym.hasSelection();
         },
         getBodyHtml: function () {
             var wym = this;


### PR DESCRIPTION
You might call this a usability issue, but it too me 15 minutes to figure out why these dialogs worked sometimes and not others. I thought there was some deeper kind of bug. Has this always been the case?