### PR TITLE
Changing `img` `src` attr causes wrong dimensions in image resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ WYMeditor.
 
 * [#757](https://github.com/wymeditor/wymeditor/issues/757)
   Fix: Trying to resize image results in zero size image
+* [#758](https://github.com/wymeditor/wymeditor/issues/758)
+  Fix: Changing `img` `src` attr causes wrong dimensions in image resize
 
 ## 1.1.0
 

--- a/src/test/unit/specific_feature_tests/images.js
+++ b/src/test/unit/specific_feature_tests/images.js
@@ -49,6 +49,82 @@ test("Inserts image into the body", function () {
     });
 });
 
+module("images-_updateImageAttrs", {setup: prepareUnitTestModule});
+
+test("Updates image attributes", function () {
+    manipulationTestHelper({
+        startHtml: '<p><img alt="fooalt" src="foosrc" title="footitle" /></p>',
+        manipulationFunc: function (wymeditor) {
+            var img = wymeditor.body().childNodes[0].childNodes[0];
+            wymeditor._updateImageAttrs(img, {
+                src: 'barsrc',
+                alt: 'baralt',
+                title: 'bartitle'
+            });
+        },
+        expectedResultHtml: [''
+            , '<p>'
+                , '<img alt="baralt" src="barsrc" title="bartitle" />'
+            , '</p>'
+        ].join('')
+    });
+});
+
+test("on `src` attr change, remove `height` & `width` attrs", function () {
+    manipulationTestHelper({
+        startHtml: '<p><img height="10" src="foo" width="10" /></p>',
+        manipulationFunc: function (wymeditor) {
+            var img = wymeditor.body().childNodes[0].childNodes[0];
+            wymeditor._updateImageAttrs(img, {src: 'bar'});
+        },
+        expectedResultHtml: '<p><img src="bar" /></p>'
+    });
+});
+
+test("on `src` attr change, nullify `DimensionsRatio` data", function () {
+    var PHI = 0.618;
+    manipulationTestHelper({
+        startHtml: '<p><img src="foo" /></p>',
+        prepareFunc: function (wymeditor) {
+            expectOneMore();
+            var $img = wymeditor.$body().find('img');
+            $img.data('DimensionsRatio', PHI);
+            strictEqual($img.data('DimensionsRatio'), PHI);
+        },
+        manipulationFunc: function (wymeditor) {
+            var img = wymeditor.body().childNodes[0].childNodes[0];
+            wymeditor._updateImageAttrs(img, {src: 'bar'});
+        },
+        additionalAssertionsFunc: function (wymeditor) {
+            expectOneMore();
+            var $img = wymeditor.$body().find('img');
+            strictEqual($img.data('DimensionsRatio'), null);
+        }
+    });
+});
+
+test("no `src` attr change, not changing `DimensionsRatio` data", function () {
+    var PHI = 0.618;
+    manipulationTestHelper({
+        startHtml: '<p><img src="foo" /></p>',
+        prepareFunc: function (wymeditor) {
+            expectOneMore();
+            var $img = wymeditor.$body().find('img');
+            $img.data('DimensionsRatio', PHI);
+            strictEqual($img.data('DimensionsRatio'), PHI);
+        },
+        manipulationFunc: function (wymeditor) {
+            var img = wymeditor.body().childNodes[0].childNodes[0];
+            wymeditor._updateImageAttrs(img, {src: 'foo'});
+        },
+        additionalAssertionsFunc: function (wymeditor) {
+            expectOneMore();
+            var $img = wymeditor.$body().find('img');
+            strictEqual($img.data('DimensionsRatio'), PHI);
+        }
+    });
+});
+
 module("images-getSelectedImage", {setup: prepareUnitTestModule});
 
 var getSelectedImageHtml = [""

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1803,6 +1803,30 @@ WYMeditor.editor.prototype.insertImage = function (attrs) {
 };
 
 /**
+    editor._updateImageAttrs
+    ========================
+
+    Updates provided `img`'s attributes with provided `attrs`.
+*/
+WYMeditor.editor.prototype._updateImageAttrs = function (img, attrs) {
+    var $img = jQuery(img);
+    if (attrs.src !== $img.attr('src')) {
+        // this data is used in the ImageHandler.
+        // height/width ratio is now most likely invalid
+        $img.data('DimensionsRatio', null);
+
+        // since the height/width ration is most likely different
+        // these proportions are most likely wrong.
+        // easiest solution is to remove them
+        // and let the user deal with
+        // the real size of the source image
+        // and he'll be able to resize it
+        $img.removeAttr('height').removeAttr('width');
+    }
+    $img.attr(attrs);
+};
+
+/**
     editor.toggleHtml
     =================
 

--- a/src/wymeditor/editor/dialogs.js
+++ b/src/wymeditor/editor/dialogs.js
@@ -405,7 +405,8 @@ WYMeditor.DIALOGS = {
             wym.focusOnDocument();
 
             if (selectedImage) {
-                jQuery(selectedImage).attr(imgAttrs);
+                wym._updateImageAttrs(selectedImage, imgAttrs);
+                wym.registerModification();
             } else {
                 wym.insertImage(imgAttrs);
             }


### PR DESCRIPTION
The image dialog should flag the image (whose `src` was updated) as such.

The `ImageHandler` should detect that and reset the `DimensionsRatio` data attribute.