### PR TITLE
Click on selection does not collapse it into caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ WYMeditor.
   Fix: Trying to resize image results in zero size image
 * [#758](https://github.com/wymeditor/wymeditor/issues/758)
   Fix: Changing `img` `src` attr causes wrong dimensions in image resize
+* [#759](https://github.com/wymeditor/wymeditor/issues/759)
+  Fix: Click on selection does not collapse it into caret
 
 ## 1.1.0
 

--- a/src/wymeditor/editor/image-handler.js
+++ b/src/wymeditor/editor/image-handler.js
@@ -539,12 +539,18 @@ WYMeditor.ImageHandler.prototype._resizeImage = function (currentMouseY) {
 };
 
 WYMeditor.ImageHandler.prototype._onMouseup = function () {
+    // this could be a case where
+    // there was a `mousedown` on a selection
+    // and then a `mouseup` without having moved the mouse.
+    // the default action would be
+    // to collapse the selection to a caret where the pointer is.
+    // we'd not like to prevent that
+
     var ih = this;
 
     if (ih._resizingNow) {
         ih._stopResize();
     }
-    return false;
 };
 
 WYMeditor.ImageHandler.prototype._stopResize = function () {


### PR DESCRIPTION
Back in `v1.0.7` there's no such issue.

Most likely a default action prevented in some handler.