### PR TITLE
Do not suggest image drag and drop in IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ WYMeditor.
   Fix: Changing `img` `src` attr causes wrong dimensions in image resize
 * [#759](https://github.com/wymeditor/wymeditor/issues/759)
   Fix: Click on selection does not collapse it into caret
+* [#760](https://github.com/wymeditor/wymeditor/issues/760)
+  Fix: Do not suggest drag and drop of images in IE8
 
 ## 1.1.0
 

--- a/src/wymeditor/editor/image-handler.js
+++ b/src/wymeditor/editor/image-handler.js
@@ -12,6 +12,10 @@
  * When IE8 is not longer supported,
  * `rem` could be used for more accurate UI element dimensions
  *
+ * Dragging and dropping of images is not suggested in the UI.
+ * See the `_isImgDragDropAllowed` function
+ * and the `_onImgMousedown` function.
+ *
  * ## IE9 Shenanigans
  *
  * Dragging and dropping of images is disabled.
@@ -68,7 +72,7 @@ WYMeditor.ImageHandler = function (wym) {
 WYMeditor.ImageHandler._isImgDragDropAllowed = function () {
     var browser = jQuery.browser;
     if (browser.msie) {
-        if (browser.versionNumber === 9) {
+        if (browser.versionNumber <= 9) {
             // dragging and dropping seems to not consistently work.
             // the image would only some times get picked up by the mouse drag attempt.
             // to prevent confusion
@@ -575,6 +579,7 @@ WYMeditor.ImageHandler.prototype._onImgMousedown = function (evt) {
     }
 
     // returning false here prevents drag of image
+    // except for in IE8
     return ih._imgDragDropAllowed;
 };
 


### PR DESCRIPTION
Image dragging and dropping in IE8 seems to be, like in IE9, unstable.

I didn't figure out a way to disallow it. Giving up.