### PR TITLE
Throws when attempting to change multiple root containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ WYMeditor.
   followed by native edits, now register undo points.
   Previously, for example, typing some letters, clicking somewhere else
   and then typing some letters again, would not produce an undo point.
+* [#745](https://github.com/wymeditor/wymeditor/pull/745)
+  Do not throw when attempting to `setRootContainer`
+  of multiple root containers.
 
 ## 1.1.1
 

--- a/src/test/unit/specific_feature_tests/set-root-container.js
+++ b/src/test/unit/specific_feature_tests/set-root-container.js
@@ -1,4 +1,5 @@
 /* global
+    makeTextSelection,
     prepareUnitTestModule,
     manipulationTestHelper,
     vanishAllWyms,
@@ -138,5 +139,30 @@ test("unwrap blockquote", function () {
         },
         manipulationClickSelector: '.wym_containers_blockquote a',
         expectedResultHtml: '<p>Foo</p><p id="bar">Bar</p>'
+    });
+});
+
+module("setRootContainer-noop", {setup: prepareUnitTestModule});
+
+test("noop when selection across multiple root containers", function () {
+    var pFooBarNoChangeHtml = '<p>foo</p><p>bar</p>';
+    manipulationTestHelper({
+        startHtml: pFooBarNoChangeHtml,
+        prepareFunc: function (wymeditor) {
+            var $body = wymeditor.$body();
+            var pFoo = $body.find('p').first()[0];
+            var pBar = $body.find('p').last()[0];
+            makeTextSelection(
+                wymeditor,
+                pFoo,
+                pBar,
+                0,
+                3
+            );
+        },
+        manipulationFunc: function (wymeditor) {
+            wymeditor.setRootContainer('h1');
+        },
+        expectedResultHtml: pFooBarNoChangeHtml
     });
 });

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1028,7 +1028,7 @@ WYMeditor.editor.prototype.getRootContainer = function () {
 */
 WYMeditor.editor.prototype.setRootContainer = function (sType) {
     var wym = this,
-        container = null,
+        selectedContainer = null,
         aTypes,
         newNode,
         blockquote,
@@ -1037,32 +1037,32 @@ WYMeditor.editor.prototype.setRootContainer = function (sType) {
         firstNode,
         x;
 
-    container = wym.selectedContainer();
-    if (!container) {
+    selectedContainer = wym.selectedContainer();
+    if (!selectedContainer) {
         return false;
     }
 
     if (sType.toLowerCase() === WYMeditor.TH) {
         // Find the TD or TH container
-        switch (container.tagName.toLowerCase()) {
+        switch (selectedContainer.tagName.toLowerCase()) {
 
         case WYMeditor.TD:
         case WYMeditor.TH:
             break;
         default:
             aTypes = [WYMeditor.TD, WYMeditor.TH];
-            container = wym.findUp(wym.selectedContainer(), aTypes);
+            selectedContainer = wym.findUp(wym.selectedContainer(), aTypes);
             break;
         }
 
         // If it exists, switch
-        if (container !== null) {
+        if (selectedContainer !== null) {
             sType = WYMeditor.TD;
-            if (container.tagName.toLowerCase() === WYMeditor.TD) {
+            if (selectedContainer.tagName.toLowerCase() === WYMeditor.TD) {
                 sType = WYMeditor.TH;
             }
             wym.restoreSelectionAfterManipulation(function () {
-                wym.switchTo(container, sType, false);
+                wym.switchTo(selectedContainer, sType, false);
                 return true;
             });
             wym.update();
@@ -1082,9 +1082,9 @@ WYMeditor.editor.prototype.setRootContainer = function (sType) {
             WYMeditor.PRE,
             WYMeditor.BLOCKQUOTE
         ];
-        container = wym.findUp(container, aTypes);
+        selectedContainer = wym.findUp(selectedContainer, aTypes);
 
-        if (container) {
+        if (selectedContainer) {
             if (sType.toLowerCase() === WYMeditor.BLOCKQUOTE) {
                 // Blockquotes must contain a block level element
                 blockquote = wym.findUp(
@@ -1093,8 +1093,8 @@ WYMeditor.editor.prototype.setRootContainer = function (sType) {
                 );
                 if (blockquote === null) {
                     newNode = wym._doc.createElement(sType);
-                    container.parentNode.insertBefore(newNode, container);
-                    newNode.appendChild(container);
+                    selectedContainer.parentNode.insertBefore(newNode, selectedContainer);
+                    newNode.appendChild(selectedContainer);
                     wym.setCaretIn(newNode.firstChild);
                 } else {
                     nodes = blockquote.childNodes;
@@ -1117,7 +1117,7 @@ WYMeditor.editor.prototype.setRootContainer = function (sType) {
             } else {
                 // Not a blockquote
                 wym.restoreSelectionAfterManipulation(function () {
-                    wym.switchTo(container, sType, false);
+                    wym.switchTo(selectedContainer, sType, false);
                     return true;
                 });
             }

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1037,9 +1037,12 @@ WYMeditor.editor.prototype.setRootContainer = function (sType) {
         firstNode,
         x;
 
-    if (sType.toLowerCase() === WYMeditor.TH) {
-        container = wym.selectedContainer();
+    container = wym.selectedContainer();
+    if (!container) {
+        return false;
+    }
 
+    if (sType.toLowerCase() === WYMeditor.TH) {
         // Find the TD or TH container
         switch (container.tagName.toLowerCase()) {
 
@@ -1079,7 +1082,7 @@ WYMeditor.editor.prototype.setRootContainer = function (sType) {
             WYMeditor.PRE,
             WYMeditor.BLOCKQUOTE
         ];
-        container = wym.findUp(wym.selectedContainer(), aTypes);
+        container = wym.findUp(container, aTypes);
 
         if (container) {
             if (sType.toLowerCase() === WYMeditor.BLOCKQUOTE) {


### PR DESCRIPTION
[In `setRootContainer`](https://github.com/wymeditor/wymeditor/blob/9311f8035bafc0f412bf47a98a0aa31d8df9aa56/src/wymeditor/editor/base.js#L1049) there is no check whether `selectedContainer` returns `false`, which is not a valid value for `findUp`.