### PR TITLE
`undoRedo.registerModification` should be called on UI interaction

### DIFF
--- a/src/test/unit/plugin_tests/table_test.js
+++ b/src/test/unit/plugin_tests/table_test.js
@@ -713,8 +713,7 @@ test("no-op on non-table elements", function () {
             var actionElement = wymeditor.$body().find('#p_1')[0];
             wymeditor.tableEditor.addColumn(actionElement);
         },
-        expectedResultHtml: basicWithPHtml,
-        testUndoRedo: true
+        expectedResultHtml: basicWithPHtml
     });
 
     manipulationTestHelper({
@@ -723,8 +722,7 @@ test("no-op on non-table elements", function () {
             var actionElement = wymeditor.$body().find('#p_1')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: basicWithPHtml,
-        testUndoRedo: true
+        expectedResultHtml: basicWithPHtml
     });
 
     manipulationTestHelper({
@@ -733,8 +731,7 @@ test("no-op on non-table elements", function () {
             var actionElement = wymeditor.$body().find('#p_1')[0];
             wymeditor.tableEditor.addRow(actionElement);
         },
-        expectedResultHtml: basicWithPHtml,
-        testUndoRedo: true
+        expectedResultHtml: basicWithPHtml
     });
 
     manipulationTestHelper({
@@ -743,8 +740,7 @@ test("no-op on non-table elements", function () {
             var actionElement = wymeditor.$body().find('#p_1')[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: basicWithPHtml,
-        testUndoRedo: true
+        expectedResultHtml: basicWithPHtml
     });
 });
 
@@ -756,8 +752,7 @@ test("Column mid column", function () {
             var actionElement = wymeditor.$body().find('#td_3_2')[0];
             wymeditor.tableEditor.addColumn(actionElement);
         },
-        expectedResultHtml: addColumnTd32Html,
-        testUndoRedo: true
+        expectedResultHtml: addColumnTd32Html
     });
 
     manipulationTestHelper({
@@ -766,8 +761,7 @@ test("Column mid column", function () {
             var actionElement = wymeditor.$body().find('#td_3_2 + td')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: basicTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: basicTableHtml
     });
 });
 
@@ -779,8 +773,7 @@ test("Column from span", function () {
             var actionElement = wymeditor.$body().find('#span_2_1')[0];
             wymeditor.tableEditor.addColumn(actionElement);
         },
-        expectedResultHtml: addColumnSpan21Html,
-        testUndoRedo: true
+        expectedResultHtml: addColumnSpan21Html
     });
 
     manipulationTestHelper({
@@ -789,8 +782,7 @@ test("Column from span", function () {
             var actionElement = wymeditor.$body().find('#td_2_1 + td')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: basicTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: basicTableHtml
     });
 });
 
@@ -802,8 +794,7 @@ test("Row end row", function () {
             var actionElement = wymeditor.$body().find('#td_3_2')[0];
             wymeditor.tableEditor.addRow(actionElement);
         },
-        expectedResultHtml: addRowTd32Html,
-        testUndoRedo: true
+        expectedResultHtml: addRowTd32Html
     });
 
     manipulationTestHelper({
@@ -812,8 +803,7 @@ test("Row end row", function () {
             var actionElement = wymeditor.$body().find('#tr_3 + tr td').eq(1)[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: basicTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: basicTableHtml
     });
 });
 
@@ -825,8 +815,7 @@ test("Row from span", function () {
             var actionElement = wymeditor.$body().find('#span_2_1')[0];
             wymeditor.tableEditor.addRow(actionElement);
         },
-        expectedResultHtml: addRowSpan21Html,
-        testUndoRedo: true
+        expectedResultHtml: addRowSpan21Html
     });
 
     manipulationTestHelper({
@@ -835,8 +824,7 @@ test("Row from span", function () {
             var actionElement = wymeditor.$body().find('#tr_2 + tr td')[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: basicTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: basicTableHtml
     });
 });
 
@@ -848,8 +836,7 @@ test("Deleting all rows removes table", function () {
             var actionElement = wymeditor.$body().find('#td_3_1')[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: removedRow3Html,
-        testUndoRedo: true
+        expectedResultHtml: removedRow3Html
     });
 
     manipulationTestHelper({
@@ -858,8 +845,7 @@ test("Deleting all rows removes table", function () {
             var actionElement = wymeditor.$body().find('#td_2_1')[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: removedRow2And3Html,
-        testUndoRedo: true
+        expectedResultHtml: removedRow2And3Html
     });
 
     manipulationTestHelper({
@@ -868,8 +854,7 @@ test("Deleting all rows removes table", function () {
             var actionElement = wymeditor.$body().find('#td_1_1')[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: '<br />',
-        testUndoRedo: true
+        expectedResultHtml: '<br />'
     });
 });
 
@@ -881,8 +866,7 @@ test("Deleting all columns removes table", function () {
             var actionElement = wymeditor.$body().find('#td_3_3')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: removedColumn3Html,
-        testUndoRedo: true
+        expectedResultHtml: removedColumn3Html
     });
 
     manipulationTestHelper({
@@ -891,8 +875,7 @@ test("Deleting all columns removes table", function () {
             var actionElement = wymeditor.$body().find('#td_2_2')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: removedColumn3And2Html,
-        testUndoRedo: true
+        expectedResultHtml: removedColumn3And2Html
     });
 
     manipulationTestHelper({
@@ -901,8 +884,7 @@ test("Deleting all columns removes table", function () {
             var actionElement = wymeditor.$body().find('#span_2_1')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: '<br />',
-        testUndoRedo: true
+        expectedResultHtml: '<br />'
     });
 });
 
@@ -1025,8 +1007,7 @@ test("Row", function () {
             var actionElement = wymeditor.$body().find('#td_3_2')[0];
             wymeditor.tableEditor.addRow(actionElement);
         },
-        expectedResultHtml: addRowFancyTd32,
-        testUndoRedo: true
+        expectedResultHtml: addRowFancyTd32
     });
 
     manipulationTestHelper({
@@ -1035,8 +1016,7 @@ test("Row", function () {
             var actionElement = wymeditor.$body().find('#tr_3 + tr td')[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: fancyTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: fancyTableHtml
     });
 });
 
@@ -1048,8 +1028,7 @@ test("Row in colspan", function () {
             var actionElement = wymeditor.$body().find('#td_1_2')[0];
             wymeditor.tableEditor.addRow(actionElement);
         },
-        expectedResultHtml: addRowFancyTd12,
-        testUndoRedo: true
+        expectedResultHtml: addRowFancyTd12
     });
 
     manipulationTestHelper({
@@ -1058,8 +1037,7 @@ test("Row in colspan", function () {
             var actionElement = wymeditor.$body().find('#tr_1 + tr td')[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: fancyTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: fancyTableHtml
     });
 });
 
@@ -1072,8 +1050,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_2_2')[0];
                 wymeditor.tableEditor.addRow(actionElement);
             },
-            expectedResultHtml: addRowFancyTd22,
-            testUndoRedo: true
+            expectedResultHtml: addRowFancyTd22
         });
 
         manipulationTestHelper({
@@ -1082,8 +1059,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#tr_2 + tr td')[0];
                 wymeditor.tableEditor.removeRow(actionElement);
             },
-            expectedResultHtml: fancyTableHtml,
-            testUndoRedo: true
+            expectedResultHtml: fancyTableHtml
         });
     });
 }
@@ -1097,8 +1073,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_1_2')[0];
                 wymeditor.tableEditor.addColumn(actionElement);
             },
-            expectedResultHtml: addColumnFancyTd12,
-            testUndoRedo: true
+            expectedResultHtml: addColumnFancyTd12
         });
 
         manipulationTestHelper({
@@ -1107,8 +1082,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_1_2 + td')[0];
                 wymeditor.tableEditor.removeColumn(actionElement);
             },
-            expectedResultHtml: fancyTableHtml,
-            testUndoRedo: true
+            expectedResultHtml: fancyTableHtml
         });
     });
 }
@@ -1122,8 +1096,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_2_3')[0];
                 wymeditor.tableEditor.addColumn(actionElement);
             },
-            expectedResultHtml: addColumnFancyTd23,
-            testUndoRedo: true
+            expectedResultHtml: addColumnFancyTd23
         });
 
         manipulationTestHelper({
@@ -1132,8 +1105,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_2_3 + td')[0];
                 wymeditor.tableEditor.removeColumn(actionElement);
             },
-            expectedResultHtml: fancyTableHtml,
-            testUndoRedo: true
+            expectedResultHtml: fancyTableHtml
         });
     });
 }
@@ -1147,8 +1119,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_3_2')[0];
                 wymeditor.tableEditor.addColumn(actionElement);
             },
-            expectedResultHtml: addColumnFancyTd32,
-            testUndoRedo: true
+            expectedResultHtml: addColumnFancyTd32
         });
 
         manipulationTestHelper({
@@ -1157,8 +1128,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_3_2 + td')[0];
                 wymeditor.tableEditor.removeColumn(actionElement);
             },
-            expectedResultHtml: fancyTableHtml,
-            testUndoRedo: true
+            expectedResultHtml: fancyTableHtml
         });
     });
 }
@@ -1171,8 +1141,7 @@ test("Column before colspan", function () {
             var actionElement = wymeditor.$body().find('#td_1_1')[0];
             wymeditor.tableEditor.addColumn(actionElement);
         },
-        expectedResultHtml: addColumnFancyTd11,
-        testUndoRedo: true
+        expectedResultHtml: addColumnFancyTd11
     });
 
     manipulationTestHelper({
@@ -1181,8 +1150,7 @@ test("Column before colspan", function () {
             var actionElement = wymeditor.$body().find('#td_1_1 + td')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: fancyTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: fancyTableHtml
     });
 });
 
@@ -1194,8 +1162,7 @@ test("Column in span", function () {
             var actionElement = wymeditor.$body().find('#span_2_1')[0];
             wymeditor.tableEditor.addColumn(actionElement);
         },
-        expectedResultHtml: addColumnFancyTd21,
-        testUndoRedo: true
+        expectedResultHtml: addColumnFancyTd21
     });
 
     manipulationTestHelper({
@@ -1204,8 +1171,7 @@ test("Column in span", function () {
             var actionElement = wymeditor.$body().find('#td_2_1 + td')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: fancyTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: fancyTableHtml
     });
 });
 
@@ -1218,8 +1184,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_2_2')[0];
                 wymeditor.tableEditor.addColumn(actionElement);
             },
-            expectedResultHtml: addColumnFancyTd22,
-            testUndoRedo: true
+            expectedResultHtml: addColumnFancyTd22
         });
 
         manipulationTestHelper({
@@ -1228,8 +1193,7 @@ if (!SKIP_KNOWN_FAILING_TESTS) {
                 var actionElement = wymeditor.$body().find('#td_2_2 + td')[0];
                 wymeditor.tableEditor.removeColumn(actionElement);
             },
-            expectedResultHtml: fancyTableHtml,
-            testUndoRedo: true
+            expectedResultHtml: fancyTableHtml
         });
     });
 }
@@ -1242,8 +1206,7 @@ test("Column with TH mid column", function () {
             var actionElement = wymeditor.$body().find('#td_3_2')[0];
             wymeditor.tableEditor.addColumn(actionElement);
         },
-        expectedResultHtml: addColumnThTd32Html,
-        testUndoRedo: true
+        expectedResultHtml: addColumnThTd32Html
     });
 
     manipulationTestHelper({
@@ -1252,8 +1215,7 @@ test("Column with TH mid column", function () {
             var actionElement = wymeditor.$body().find('#td_3_2 + td')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: thTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: thTableHtml
     });
 });
 
@@ -1265,8 +1227,7 @@ test("Column with TH in th", function () {
             var actionElement = wymeditor.$body().find('#th_1_3')[0];
             wymeditor.tableEditor.addColumn(actionElement);
         },
-        expectedResultHtml: addColumnThTh13Html,
-        testUndoRedo: true
+        expectedResultHtml: addColumnThTh13Html
     });
 
     manipulationTestHelper({
@@ -1275,8 +1236,7 @@ test("Column with TH in th", function () {
             var actionElement = wymeditor.$body().find('#th_1_3 + th')[0];
             wymeditor.tableEditor.removeColumn(actionElement);
         },
-        expectedResultHtml: thTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: thTableHtml
     });
 });
 
@@ -1288,8 +1248,7 @@ test("Row with TH end row", function () {
             var actionElement = wymeditor.$body().find('#td_3_2')[0];
             wymeditor.tableEditor.addRow(actionElement);
         },
-        expectedResultHtml: addRowThTd32Html,
-        testUndoRedo: true
+        expectedResultHtml: addRowThTd32Html
     });
 
     manipulationTestHelper({
@@ -1298,8 +1257,7 @@ test("Row with TH end row", function () {
             var actionElement = wymeditor.$body().find('#tr_3 + tr td').eq(1)[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: thTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: thTableHtml
     });
 });
 
@@ -1311,8 +1269,7 @@ test("Row with TH first th row", function () {
             var actionElement = wymeditor.$body().find('#th_1_3')[0];
             wymeditor.tableEditor.addRow(actionElement);
         },
-        expectedResultHtml: addRowThTh13Html,
-        testUndoRedo: true
+        expectedResultHtml: addRowThTh13Html
     });
 
     manipulationTestHelper({
@@ -1321,8 +1278,7 @@ test("Row with TH first th row", function () {
             var actionElement = wymeditor.$body().find('#tr_1 + tr td').eq(2)[0];
             wymeditor.tableEditor.removeRow(actionElement);
         },
-        expectedResultHtml: thTableHtml,
-        testUndoRedo: true
+        expectedResultHtml: thTableHtml
     });
 });
 

--- a/src/test/unit/specific_feature_tests/class_toggling.js
+++ b/src/test/unit/specific_feature_tests/class_toggling.js
@@ -50,7 +50,6 @@ test("No change when no selection", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.toggleClass("foo", "p");
         },
-        testUndoRedo: true,
         manipulationClickSelector: ".wym_classes_foo a",
         expectedResultHtml: noChangeHtml
     });
@@ -63,7 +62,6 @@ test("Adds className", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.toggleClass("foo", "p");
         },
-        testUndoRedo: true,
         manipulationClickSelector: ".wym_classes_foo a",
         expectedResultHtml: "<p class=\"foo\">Foo</p>"
     });
@@ -76,7 +74,6 @@ test("Removes className", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.toggleClass("foo", "p");
         },
-        testUndoRedo: true,
         manipulationClickSelector: ".wym_classes_foo a",
         expectedResultHtml: "<p>Foo</p>"
     });
@@ -89,7 +86,6 @@ test("Adds className, keeping existing ones", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.toggleClass("foo", "p");
         },
-        testUndoRedo: true,
         manipulationClickSelector: ".wym_classes_foo a",
         expectedResultHtml: "<p class=\"bar foo\">Foo</p>"
     });
@@ -102,7 +98,6 @@ test("Removes className, keeping all others", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.toggleClass("foo", "p");
         },
-        testUndoRedo: true,
         manipulationClickSelector: ".wym_classes_foo a",
         expectedResultHtml: "<p class=\"bar baz\">Foo</p>"
     });
@@ -131,7 +126,6 @@ test("Adds className, selector determines element", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.toggleClass("bar", "ul");
         },
-        testUndoRedo: true,
         manipulationClickSelector: ".wym_classes_bar a",
         expectedResultHtml: [""
             , "<ul>"
@@ -168,7 +162,6 @@ test("Adds className to image", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.toggleClass("fancy", "img");
         },
-        testUndoRedo: true,
         manipulationClickSelector: ".wym_classes_fancy a",
         expectedResultHtml: [""
             , "<p>"

--- a/src/test/unit/specific_feature_tests/exec_toggles.js
+++ b/src/test/unit/specific_feature_tests/exec_toggles.js
@@ -78,8 +78,7 @@ function wrapNonWrappedSelection(command) {
             wymeditor.exec(command);
         },
         expectedResultHtml: "<p><" + tagName + ">Foo</" + tagName + "></p>",
-        manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true
+        manipulationKeyCombo: getExecKeyboardShortcut(command)
     });
 }
 
@@ -117,8 +116,7 @@ function unwrapWrappedSelection(command) {
             wymeditor.exec(command);
         },
         expectedResultHtml: "<p>Foo</p>",
-        manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true
+        manipulationKeyCombo: getExecKeyboardShortcut(command)
     });
 }
 
@@ -156,8 +154,7 @@ function unwrapWrappedSelectionPartially(command) {
             wymeditor.exec(command);
         },
         expectedResultHtml: "<p><" + tagName + ">Fo</" + tagName + ">o</p>",
-        manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true
+        manipulationKeyCombo: getExecKeyboardShortcut(command)
     });
 }
 
@@ -197,7 +194,6 @@ function wrapPartiallyWrappedSelection(command, skipFunc) {
         },
         expectedResultHtml: "<p><" + tagName + ">Foo</" + tagName + "></p>",
         manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true,
         skipFunc: skipFunc
     });
 }
@@ -269,7 +265,6 @@ function unwrapPartiallyWrappedSelection(command, skipFunc) {
         },
         expectedResultHtml: "<p>Foo</p>",
         manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true,
         skipFunc: skipFunc
     });
 }
@@ -342,8 +337,7 @@ function wrapsAcrossRootContainers(command) {
             "<p>F<" + tagName + ">oo</" + tagName + "></p>",
             "<p><" + tagName + ">Ba</" + tagName + ">r</p>"
         ].join(''),
-        manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true
+        manipulationKeyCombo: getExecKeyboardShortcut(command)
     });
 }
 
@@ -386,8 +380,7 @@ function unwrapsAcrossRootContainers(command) {
             wymeditor.exec(command);
         },
         expectedResultHtml: "<p>Foo</p><p>Bar</p>",
-        manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true
+        manipulationKeyCombo: getExecKeyboardShortcut(command)
     });
 }
 
@@ -446,8 +439,7 @@ function wrapsFromInsideLiToChildOfSiblingLi(command) {
                     closeTag + "<span id=\"span\">" + openTag + "ba" + closeTag + "r</span></li>"
             , "</ul>"
         ].join(''),
-        manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true
+        manipulationKeyCombo: getExecKeyboardShortcut(command)
     });
 }
 
@@ -486,8 +478,7 @@ function unwrapsFromInsideLiToChildOfSiblingLi(command) {
                 , "<li>This:<br /><span>bar</span></li>"
             , "</ul>"
         ].join(''),
-        manipulationKeyCombo: getExecKeyboardShortcut(command),
-        testUndoRedo: true
+        manipulationKeyCombo: getExecKeyboardShortcut(command)
     });
 }
 

--- a/src/test/unit/specific_feature_tests/images.js
+++ b/src/test/unit/specific_feature_tests/images.js
@@ -26,8 +26,7 @@ test("Inserts image into a paragraph", function () {
             });
         },
         expectedResultHtml: "<p><img alt=\"Example\" " +
-            "src=\"" + IMG_SRC + "\" />Foo</p>",
-        testUndoRedo: true
+            "src=\"" + IMG_SRC + "\" />Foo</p>"
     });
 });
 
@@ -44,8 +43,7 @@ test("Inserts image into the body", function () {
             });
         },
         expectedResultHtml: "<img alt=\"Example\" " +
-            "src=\"" + IMG_SRC + "\" /><br />",
-        testUndoRedo: true
+            "src=\"" + IMG_SRC + "\" /><br />"
     });
 });
 

--- a/src/test/unit/specific_feature_tests/links.js
+++ b/src/test/unit/specific_feature_tests/links.js
@@ -30,8 +30,7 @@ test("Inserts link with attributes", function () {
             wymeditor.link({href: 'http://example.com/', title: 'Example'});
         },
         expectedResultHtml: "<p>Foo<a href=\"http://example.com/\" " +
-            "title=\"Example\">bar</a></p>",
-        testUndoRedo: true
+            "title=\"Example\">bar</a></p>"
     });
 });
 test("Modifies link attributes", function () {
@@ -42,8 +41,7 @@ test("Modifies link attributes", function () {
             wymeditor.link({href: "http://example.com/baz", target: "_blank"});
         },
         expectedResultHtml: "<p><a href=\"http://example.com/baz\"" +
-            " target=\"_blank\">Bar</a></p>",
-        testUndoRedo: true
+            " target=\"_blank\">Bar</a></p>"
     });
 });
 
@@ -63,8 +61,7 @@ test("Unlinks entirely linked selection", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.exec(WYMeditor.EXEC_COMMANDS.UNLINK);
         },
-        expectedResultHtml: "<p>Foo</p>",
-        testUndoRedo: true
+        expectedResultHtml: "<p>Foo</p>"
     });
 });
 
@@ -85,7 +82,6 @@ test("Non-IE browsers partially unlink according to selection", function () {
             wymeditor.exec(WYMeditor.EXEC_COMMANDS.UNLINK);
         },
         expectedResultHtml: "<p><a href=\"http://example.com/\">Fo</a>o</p>",
-        testUndoRedo: true,
         skipFunc: function () {
             if (jQuery.browser.name === "msie") {
                 return SKIP_THIS_TEST;
@@ -111,7 +107,6 @@ test("IE entirely unlinks regardless of selection", function () {
             wymeditor.exec(WYMeditor.EXEC_COMMANDS.UNLINK);
         },
         expectedResultHtml: "<p>Foo</p>",
-        testUndoRedo: true,
         skipFunc: function () {
             if (jQuery.browser.name !== "msie") {
                 return SKIP_THIS_TEST;
@@ -139,8 +134,7 @@ test("Unlinks across root containers", function () {
         manipulationFunc: function (wymeditor) {
             wymeditor.exec(WYMeditor.EXEC_COMMANDS.UNLINK);
         },
-        expectedResultHtml: "<p>Foo</p><p>Bar</p>",
-        testUndoRedo: true
+        expectedResultHtml: "<p>Foo</p><p>Bar</p>"
     });
 });
 
@@ -163,7 +157,6 @@ test("Non-IE browsers don't unlink when collapsed selection " +
             wymeditor.exec(WYMeditor.EXEC_COMMANDS.UNLINK);
         },
         expectedResultHtml: noChangeHtml,
-        testUndoRedo: true,
         skipFunc: function () {
             if (jQuery.browser.name === "msie") {
                 return SKIP_THIS_TEST;
@@ -189,7 +182,6 @@ test("IE unlinks when collapsed selection inside link", function () {
             wymeditor.exec(WYMeditor.EXEC_COMMANDS.UNLINK);
         },
         expectedResultHtml: "<p>Foo</p>",
-        testUndoRedo: true,
         skipFunc: function () {
             if (jQuery.browser.name !== "msie") {
                 return SKIP_THIS_TEST;

--- a/src/test/unit/specific_feature_tests/lists.js
+++ b/src/test/unit/specific_feature_tests/lists.js
@@ -2770,8 +2770,7 @@ test("Tab key indents", function () {
         startHtml: nestedListHtml,
         setCaretInSelector: "#li_7",
         manipulationKeyCombo: "tab",
-        expectedResultHtml: li_7_indentedHtml,
-        testUndoRedo: true
+        expectedResultHtml: li_7_indentedHtml
     });
 });
 
@@ -2794,8 +2793,7 @@ test("Shift+Tab outdents", function () {
                 , "<li id=\"li_1_1\">1_1</li>"
                 , "<li id=\"li_2\">2</li>"
             , "</ol>"
-        ].join(""),
-        testUndoRedo: true
+        ].join("")
     });
 });
 
@@ -2805,8 +2803,7 @@ test("Tab has no effect outside lists", function () {
         startHtml: noChangeHtml,
         setCaretInSelector: "#p_1",
         manipulationKeyCombo: "tab",
-        expectedResultHtml: noChangeHtml,
-        testUndoRedo: true
+        expectedResultHtml: noChangeHtml
     });
 });
 

--- a/src/test/unit/specific_feature_tests/set-root-container.js
+++ b/src/test/unit/specific_feature_tests/set-root-container.js
@@ -37,7 +37,6 @@ pairs.forEach(function (pair) {
 
     test(former + ' to ' + latter, function () {
         manipulationTestHelper({
-            testUndoRedo: true,
             startHtml: '<' + former + '>Foo</' + former + '>',
             setCaretInSelector: former,
             manipulationFunc: function (wymeditor) {
@@ -53,7 +52,6 @@ module("setRootContainer-td/th toggling", {setup: prepareUnitTestModule});
 
 test("td to th", function () {
     manipulationTestHelper({
-        testUndoRedo: true,
         startHtml: ''.concat(
             '<table>',
                 '<tbody>',
@@ -82,7 +80,6 @@ test("td to th", function () {
 
 test("th to td", function () {
     manipulationTestHelper({
-        testUndoRedo: true,
         startHtml: ''.concat(
             '<table>',
                 '<tbody>',
@@ -113,7 +110,6 @@ module("setRootContainer-blockquote toggling", {setup: prepareUnitTestModule});
 
 test("wrap in blockquote", function () {
     manipulationTestHelper({
-        testUndoRedo: true,
         startHtml: '<p id="foo">Foo</p><p>Bar</p>',
         setCaretInSelector: '#foo',
         manipulationFunc: function (wymeditor) {
@@ -131,7 +127,6 @@ test("wrap in blockquote", function () {
 
 test("unwrap blockquote", function () {
     manipulationTestHelper({
-        testUndoRedo: true,
         startHtml: '<blockquote><p>Foo</p><p id="bar">Bar</p></blockquote>',
         setCaretInSelector: '#bar',
         manipulationFunc: function (wymeditor) {

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -3803,7 +3803,6 @@ WYMeditor.editor.prototype.insertTable = function (rows, columns, caption, summa
     wym._afterInsertTable(table);
     wym.prepareDocForEditing();
 
-    wym.registerModification();
     return table;
 };
 

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1748,8 +1748,6 @@ WYMeditor.editor.prototype.link = function (attrs) {
         return;
     }
     $a.attr(attrs);
-
-    wym.registerModification();
 };
 
 /**

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -711,12 +711,7 @@ WYMeditor.editor.prototype.exec = function (cmd) {
             }
         });
         if (!custom_run) {
-            if (
-                // Deligate all other commands to `_exec`
-                wym._exec(cmd) === true
-            ) {
-                wym.registerModification();
-            }
+            return wym._exec(cmd);
         }
         break;
     }

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1791,8 +1791,6 @@ WYMeditor.editor.prototype.insertImage = function (attrs) {
 
     // PhantomJS seems to add strange spans around images.
     wym.$body().find('.Apple-style-span').children().unwrap();
-
-    wym.registerModification();
 };
 
 /**

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1174,7 +1174,6 @@ WYMeditor.editor.prototype.toggleClass = function (sClass, jqexpr) {
     if (!$element.attr(WYMeditor.CLASS)) {
         $element.removeAttr(wym._class);
     }
-    wym.registerModification();
 };
 
 /**

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -3390,7 +3390,6 @@ WYMeditor.editor.prototype._insertUnorderedList = function () {
         // We actually made some list correction
         // Don't actually perform the action if we've potentially just changed
         // the list, and maybe the list appearance as a result.
-        wym.registerModification();
         return true;
     }
 
@@ -3399,8 +3398,7 @@ WYMeditor.editor.prototype._insertUnorderedList = function () {
         return wym.insertList('ul');
     };
 
-    return wym.restoreSelectionAfterManipulation(manipulationFunc) &&
-        wym.registerModification();
+    return wym.restoreSelectionAfterManipulation(manipulationFunc);
 };
 
 /**

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -3349,7 +3349,6 @@ WYMeditor.editor.prototype._insertOrderedList = function () {
         // We actually made some list correction
         // Don't actually perform the action if we've potentially just changed
         // the list, and maybe the list appearance as a result.
-        wym.registerModification();
         return true;
     }
 
@@ -3358,8 +3357,7 @@ WYMeditor.editor.prototype._insertOrderedList = function () {
         return wym.insertList('ol');
     };
 
-    return wym.restoreSelectionAfterManipulation(manipulationFunc) &&
-        wym.registerModification();
+    return wym.restoreSelectionAfterManipulation(manipulationFunc);
 };
 
 /**

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -3245,7 +3245,6 @@ WYMeditor.editor.prototype.outdent = function () {
         // We actually made some list correction
         // Don't actually perform the action if we've potentially just changed
         // the list, and maybe the list appearance as a result.
-        wym.registerModification();
         return true;
     }
 
@@ -3277,8 +3276,7 @@ WYMeditor.editor.prototype.outdent = function () {
 
         return domChanged;
     };
-    return wym.restoreSelectionAfterManipulation(manipulationFunc) &&
-        wym.registerModification();
+    return wym.restoreSelectionAfterManipulation(manipulationFunc);
 };
 
 /**

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -1061,7 +1061,6 @@ WYMeditor.editor.prototype.setRootContainer = function (sType) {
                 return true;
             });
             wym.update();
-            wym.registerModification();
         }
     } else {
         // Set the container type
@@ -1118,7 +1117,6 @@ WYMeditor.editor.prototype.setRootContainer = function (sType) {
             }
 
             wym.update();
-            wym.registerModification();
         }
     }
 

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -3181,7 +3181,6 @@ WYMeditor.editor.prototype.indent = function () {
         // We actually made some list correction
         // Don't actually perform the action if we've potentially just changed
         // the list, and maybe the list appearance as a result.
-        wym.registerModification();
         return true;
     }
 
@@ -3212,8 +3211,7 @@ WYMeditor.editor.prototype.indent = function () {
 
         return domChanged;
     };
-    return wym.restoreSelectionAfterManipulation(manipulationFunc) &&
-        wym.registerModification();
+    return wym.restoreSelectionAfterManipulation(manipulationFunc);
 };
 
 /**

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -2040,7 +2040,6 @@ WYMeditor.editor.prototype.paste = function (str) {
             }
         }
     }
-    wym.registerModification();
 };
 
 WYMeditor.editor.prototype.insert = function (html) {


### PR DESCRIPTION
`undoRedo.registerModification` should be called only on the level of UI interaction.

For example, it should be called from the handler of a toolbar button.

It should not be called from the manipulation functions.

Why?

Because a "modification", that can be undone, from the user's perspective, is a modification that he himself triggered.

So, whatever was the result of him pressing a button should be undone.

A button could potentially call for several consecutive modifications.

In that case, we certainly don't want several history points, do we?

This is why the calls to `undoRedo.registerModificaion`  must be taken out of the modification functions/methods and put in the UI actions handlers.

And this should happen before #681, so that we don't add another thing to the modification functions.