### PR TITLE
Adding an underscore to the console warning.

### DIFF
--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -3905,7 +3905,7 @@ WYMeditor.editor.prototype._initSkin = function () {
         }
     } else {
         WYMeditor.console.warn(
-            "Chosen skin _" + wym.options.skin + "_ not found."
+            "Chosen skin _" + wym._options.skin + "_ not found."
         );
     }
 };


### PR DESCRIPTION
When a skin that is specified in wym._options cannot be found then a warning is displayed in the console. The warning had a missing underscore (_), so it caused an error.