### PR TITLE
Fix inserting images into classless spans

### DIFF
--- a/src/test/unit/specific_feature_tests/images.js
+++ b/src/test/unit/specific_feature_tests/images.js
@@ -31,6 +31,22 @@ test("Inserts image into a paragraph", function () {
     });
 });
 
+test("Inserts image into a classless span", function () {
+    manipulationTestHelper({
+        startHtml: "<span>Foo</span>",
+        setCaretInSelector: 'span',
+        manipulationFunc: function (wymeditor) {
+            wymeditor.insertImage({
+                src: IMG_SRC,
+                alt: "Example"
+            });
+        },
+        expectedResultHtml: "<span><img alt=\"Example\" " +
+        "src=\"" + IMG_SRC + "\" />Foo</span>",
+        testUndoRedo: true
+    });
+});
+
 test("Inserts image into the body", function () {
     manipulationTestHelper({
         startHtml: "<br />",

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -610,6 +610,7 @@ WYMeditor.editor.prototype._exec = function (cmd, param) {
     if (
         $span.attr("class") === "" &&
         $span.attr("style") === "font-weight: normal;" ||
+        $span.attr("class") &&
         $span.attr("class").toLowerCase() === "apple-style-span"
     ) {
         // An undesireable `span` was created. WebKit & Blink do this.


### PR DESCRIPTION
Inserting images into spans doesn't work, because it calls `toLowerCase()` on the null class attribute.  