### PR TITLE
Fix error when inserting image into a span inside a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ WYMeditor.
 ### Bug Fixes
 
 * [#777](https://github.com/wymeditor/wymeditor/pull/777)
-  Fixed error when inserting into span nested inside list.
+  Fixed script error when inserting into span nested inside list.
 * [#761](https://github.com/wymeditor/wymeditor/pull/761)
   Image resize handle below end of iframe
 * [#748](https://github.com/wymeditor/wymeditor/issues/748)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ WYMeditor.
 
 ### Bug Fixes
 
+* [#777](https://github.com/wymeditor/wymeditor/pull/777)
+  Fixed error when inserting into span nested inside list.
 * [#761](https://github.com/wymeditor/wymeditor/pull/761)
   Image resize handle below end of iframe
 * [#748](https://github.com/wymeditor/wymeditor/issues/748)

--- a/src/test/unit/specific_feature_tests/images.js
+++ b/src/test/unit/specific_feature_tests/images.js
@@ -31,6 +31,22 @@ test("Inserts image into a paragraph", function () {
     });
 });
 
+test("Inserts image into a classless span", function () {
+    manipulationTestHelper({
+        startHtml: "<span>Foo</span>",
+        setCaretInSelector: 'span',
+        manipulationFunc: function (wymeditor) {
+            wymeditor.insertImage({
+                src: IMG_SRC,
+                alt: "Example"
+            });
+        },
+        expectedResultHtml: "<span><img alt=\"Example\" " +
+        "src=\"" + IMG_SRC + "\" />Foo</span>",
+        testUndoRedo: true
+    });
+});
+
 test("Inserts image into the body", function () {
     manipulationTestHelper({
         startHtml: "<br />",

--- a/src/test/unit/specific_feature_tests/images.js
+++ b/src/test/unit/specific_feature_tests/images.js
@@ -33,7 +33,7 @@ test("Inserts image into a paragraph", function () {
 
 test("Inserts image into a span inside a list", function () {
     manipulationTestHelper({
-        startHtml: "<ol><li><span>Foo bar</span></li></ol>",
+        startHtml: "<ol><li><span>Foobar</span></li></ol>",
         prepareFunc: function(wymeditor) {
             var $span = wymeditor.$body().find('span')[0];
 
@@ -46,7 +46,7 @@ test("Inserts image into a span inside a list", function () {
             });
         },
         expectedResultHtml: "<ol><li><span>Foo<img alt=\"Example\" " +
-        "src=\"" + IMG_SRC + "\" /> bar</span></li></ol>",
+        "src=\"" + IMG_SRC + "\" />bar</span></li></ol>",
         testUndoRedo: true
     });
 });

--- a/src/test/unit/specific_feature_tests/images.js
+++ b/src/test/unit/specific_feature_tests/images.js
@@ -31,21 +31,26 @@ test("Inserts image into a paragraph", function () {
     });
 });
 
-test("Inserts image into a classless span", function () {
+test("Inserts image into a span inside a list", function () {
     manipulationTestHelper({
-        startHtml: "<span>Foo</span>",
-        setCaretInSelector: 'span',
+        startHtml: "<ol><li><span>Foo bar</span></li></ol>",
+        prepareFunc: function(wymeditor) {
+            var $span = wymeditor.$body().find('span')[0];
+
+            makeTextSelection(wymeditor, $span, $span, 3, 3);
+        },
         manipulationFunc: function (wymeditor) {
             wymeditor.insertImage({
                 src: IMG_SRC,
                 alt: "Example"
             });
         },
-        expectedResultHtml: "<span><img alt=\"Example\" " +
-        "src=\"" + IMG_SRC + "\" />Foo</span>",
+        expectedResultHtml: "<ol><li><span>Foo<img alt=\"Example\" " +
+        "src=\"" + IMG_SRC + "\" /> bar</span></li></ol>",
         testUndoRedo: true
     });
 });
+
 
 test("Inserts image into the body", function () {
     manipulationTestHelper({

--- a/src/test/unit/specific_feature_tests/images.js
+++ b/src/test/unit/specific_feature_tests/images.js
@@ -9,6 +9,7 @@
     expectMore,
     strictEqual,
     makeSelection,
+    makeTextSelection,
     IMG_SRC
 */
 "use strict";
@@ -34,7 +35,7 @@ test("Inserts image into a paragraph", function () {
 test("Inserts image into a span inside a list", function () {
     manipulationTestHelper({
         startHtml: "<ol><li><span>Foobar</span></li></ol>",
-        prepareFunc: function(wymeditor) {
+        prepareFunc: function (wymeditor) {
             var $span = wymeditor.$body().find('span')[0];
 
             makeTextSelection(wymeditor, $span, $span, 3, 3);

--- a/src/wymeditor/editor/base.js
+++ b/src/wymeditor/editor/base.js
@@ -610,6 +610,7 @@ WYMeditor.editor.prototype._exec = function (cmd, param) {
     if (
         $span.attr("class") === "" &&
         $span.attr("style") === "font-weight: normal;" ||
+        $span.attr("class") &&
         $span.attr("class").toLowerCase() === "apple-style-span"
     ) {
         // An undesireable `span` was created. WebKit & Blink do this.


### PR DESCRIPTION
There is a bug in the webkit span fixer code where when it is called on a span without a class, an error occurs.  The most common place we see this is when inserting images into spans within lists.  (Span alone causes the span to split, instead) 