### PR TITLE
Improve cleanup of image resize handler

### DIFF
--- a/src/wymeditor/editor/image-handler.js
+++ b/src/wymeditor/editor/image-handler.js
@@ -660,7 +660,7 @@ WYMeditor.ImageHandler.prototype._detachResizeHandle = function () {
         ih._$currentImg.height() >= 16 &&
         ih._$currentImg.width() >= 16
     ) {
-        ih._$currentImg.css({padding: 0, margin: 0});
+        ih._$currentImg.css({'background-color': '', padding: '', margin: ''});
     }
     ih._$currentImg = null;
     ih._$resizeHandle.hide();


### PR DESCRIPTION
Previously, the padding and margin properties were cleaned up by setting
them to 0. When external CSS rules apply to images, these would be
overridden by this.

To fix this, the rules are removed (by setting them to the empty
string), making the external rules apply again. This still means that
while hovering, the external rules are overriden, but at least they
apply again after hovering is done.

Additionally, the background-color property is now also reset, which was
previously just left around.

(I've read that this project is not actively developed anymore, but I already created this commit and wanted to share it with anyone who's interested anyway)