### PR TITLE
Do not show "pretty" annotations on .wym-editor-only elements

### DIFF
--- a/src/wymeditor/iframe/pretty/wymiframe.css
+++ b/src/wymeditor/iframe/pretty/wymiframe.css
@@ -374,6 +374,8 @@ sub:hover::before                       { content: "subscript" }
 sub[class]:hover::before                { content: "subscript type \"" attr(class) "\""}
 body.short sub:hover::before            { content: "sub" }
 body.short sub[class]:hover::before     { content: "sub." attr(class) }
+/* Hide annotations on .wym-editor-only elements (e.g. image resize handles) */
+.wym-editor-only::before                { display: none }
 
 span:hover,
 strong:hover, b:hover,


### PR DESCRIPTION
These elements are not intended as part of the content to be edited, so
there is no point in showing annotations on them.

In particular, the annotations were previously added on the image resize
handle, partly obscuring it from view and preventing the mouse pointer
from reaching the handle, making image resizing impossible using the
pretty theme.

This fixes #784.